### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,6 +253,10 @@ exports.extract = function (cwd, opts) {
 
     var onsymlink = function () {
       if (win32) return next() // skip symlinks on win for now before it can be tested
+      if (header.linkname.indexOf('..') !== -1) {
+        console.log('skipping bad symlink path', header.linkname);
+        return next();
+      }
       xfs.unlink(name, function () {
         xfs.symlink(header.linkname, name, stat)
       })
@@ -261,6 +265,10 @@ exports.extract = function (cwd, opts) {
     var onlink = function () {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
+        if (header.linkname.indexOf('..') !== -1) {
+          console.log('skipping bad link path', header.linkname);
+          return next();
+        }
         var srcpath = path.resolve(cwd, header.linkname)
 
         xfs.link(srcpath, name, function (err) {


### PR DESCRIPTION
Fixes [https://github.com/Big-Health/advanced-security-demo-javascript/security/code-scanning/1](https://github.com/Big-Health/advanced-security-demo-javascript/security/code-scanning/1)

To fix the problem, we need to ensure that the `header.linkname` does not contain any directory traversal sequences like `..` before it is used to construct a file path. This can be achieved by validating the `header.linkname` and ensuring it is a safe path.

- We will add a validation step to check if `header.linkname` contains any `..` sequences.
- If the path is deemed unsafe, we will skip processing that entry and log a warning.
- This change will be made in the `onsymlink` and `onlink` functions where `header.linkname` is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
